### PR TITLE
Added reference to CUP-ECS/spack-externals to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ bash:$ spack repo ls
 [+] builtin    v2.2    ~/.spack/package_repos/fncqgg4/repos/spack_repo/builtin
 ```
   7. Follow the instructions in the README of [CUP-ECS/spack-externals](https://github.com/CUP-ECS/spack-externals) to tell Spack about libraries externally installed on the system you are using.
-  7. Use Spack normally. Spack will automatically find libraries included in this repository.
+  8. Use Spack normally. Spack will automatically find libraries included in this repository.
 
 
 ## Package Creation:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ bash:$ spack repo ls
 [+] cupecs     v2.0    /path/to/repo/spack-packages/spack_pkgs/spack_repo/cupecs
 [+] builtin    v2.2    ~/.spack/package_repos/fncqgg4/repos/spack_repo/builtin
 ```
-  7. Use spack normally. Spack will automatically find libraries included in this repository.
+  7. Follow the instructions in the README of [CUP-ECS/spack-externals](https://github.com/CUP-ECS/spack-externals) to tell Spack about libraries externally installed on the system you are using.
+  7. Use Spack normally. Spack will automatically find libraries included in this repository.
 
 
 ## Package Creation:


### PR DESCRIPTION
Added an additional instruction asking users to copy the appropriate `package.yaml` file from [ CUP-ECS/spack-externals](https://github.com/CUP-ECS/spack-externals/) into their `~./spack` directory.