### PR TITLE
Initial setup of COMPASS Spack Packages Repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,36 @@
 ## About:
-CUP-ECS internal spack package respository.
+This repository contains a Spack package repository with custom Spack package files for various applications and libraries made and utilized by COMPASS.
+
+This repository is a fork of the CUP-ECS PSAAP-III repo by the same name. The package files from this project are still included as a separate Spack repository.
 
 ## Setup:
-
-  1. Clone spack from https://github.com/spack/spack.
+  1. Clone Spack from https://github.com/spack/spack.
   2. Clone this repository.
-  3. Set up your environment so that the ~/.spack directory is created.
-  4. Find the `repos.yaml` file in the `~/.spack` directory. If you are on a cluster, the `repos.yaml` file will be in `~./spack/{cluster name}/`, for example on tioga, `~./spack/tioga/`. Sometimes spack does not create the `repos.yaml` file for you. If so, create it yourself in the correct directory.
-  5. Register this repository by adding the following lines to the `repos.yaml` file:
+  3. Set up your environment so that Spack is loaded.
+  4. Add the repositories to Spack by running:
+```bash
+spack repo add /path/to/this/repo/spack_pkgs/spack_repo/cupecs
+spack repo add /path/to/this/repo/spack_pkgs/spack_repo/compass
 ```
-repos:
-  cupecs: /path/to/repo/spack-packages/spack_pkgs/spack_repo/cupecs
+  5. Run `spack repo list` to verify Spack has found the package repositories correctly. The output should be similar to:
 ```
-  6. Run `spack repo list` to verify spack has found the cupecs package repository. The output should be similar to:
+[+] compass    v1.0    /home/theta/git/spack-packages/spack_pkgs/spack_repo/compass
+[+] cupecs     v2.0    /home/theta/git/spack-packages/spack_pkgs/spack_repo/cupecs
+[+] builtin    v2.2    /home/theta/.spack/package_repos/fncqgg4/repos/spack_repo/builtin
 ```
-bash:$ spack repo ls
-[+] cupecs     v2.0    /path/to/repo/spack-packages/spack_pkgs/spack_repo/cupecs
-[+] builtin    v2.2    ~/.spack/package_repos/fncqgg4/repos/spack_repo/builtin
-```
-  7. Follow the instructions in the README of [CUP-ECS/spack-externals](https://github.com/CUP-ECS/spack-externals) to tell Spack about libraries externally installed on the system you are using.
-  8. Use Spack normally. Spack will automatically find libraries included in this repository.
+ 6. Use Spack normally. Spack will automatically find libraries included in this repository.
 
 
 ## Package Creation:
-Create a directory with the name of your package in `spack_pkgs/spack_repo/cupecs/packages` and place your `package.py` file in that directory.
+Create a directory with the name of your package in `spack_pkgs/spack_repo/compass/packages` and place your `package.py` file in that directory.
 
 For packages that include `CMakePackage`, `CudaPackage`, and/or `ROCmPackage`, you must include the following imports in your `packages.py` file:
-```
+```python
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
 ```
 And for other spack-related functions, import:
-```
+```python
 from spack.package import *
 ```

--- a/spack_pkgs/spack_repo/compass/packages/amg2023/package.py
+++ b/spack_pkgs/spack_repo/compass/packages/amg2023/package.py
@@ -1,0 +1,57 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack_repo.builtin.build_systems.cuda import CudaPackage
+from spack_repo.builtin.build_systems.rocm import ROCmPackage
+
+from spack.package import *
+
+
+class Amg2023(CMakePackage, CudaPackage, ROCmPackage):
+    """AMG2023 is a parallel algebraic multigrid solver for linear systems
+    arising from problems on unstructured grids. The driver provided here
+    builds linear systems for various 3-dimensional problems. It requires
+    an installation of hypre-2.27.0 or higher.
+    """
+
+    tags = ["benchmark"]
+    homepage = "https://github.com/LLNL/AMG2023"
+    git = "https://github.com/LLNL/AMG2023.git"
+
+    license("Apache-2.0")
+
+    version("develop", branch="main")
+
+    variant("mpi", default=True, description="Enable MPI support")
+    variant("openmp", default=False, description="Enable OpenMP support")
+    variant("caliper", default=False, description="Enable Caliper monitoring")
+
+    depends_on("c", type="build")  # generated
+    depends_on("cxx", type="build") # COMPASS added
+    depends_on("mpi", when="+mpi")
+    depends_on("hypre+mpi", when="+mpi")
+    requires("+mpi", when="^hypre+mpi")
+    depends_on("caliper", when="+caliper")
+    depends_on("adiak", when="+caliper")
+    depends_on("hypre+caliper", when="+caliper")
+    depends_on("hypre@2.27.0:")
+    depends_on("hypre+cuda", when="+cuda")
+    requires("+cuda", when="^hypre+cuda")
+    depends_on("hypre+rocm", when="+rocm")
+    requires("+rocm", when="^hypre+rocm")
+
+    def cmake_args(self):
+        cmake_options = []
+        cmake_options.append(self.define_from_variant("AMG_WITH_CALIPER", "caliper"))
+        cmake_options.append(self.define_from_variant("AMG_WITH_OMP", "openmp"))
+        cmake_options.append(self.define("HYPRE_PREFIX", self.spec["hypre"].prefix))
+        if self.spec["hypre"].satisfies("+cuda"):
+            cmake_options.append("-DAMG_WITH_CUDA=ON")
+        if self.spec["hypre"].satisfies("+rocm"):
+            cmake_options.append("-DAMG_WITH_HIP=ON")
+        if self.spec["hypre"].satisfies("+mpi"):
+            cmake_options.append("-DAMG_WITH_MPI=ON")
+
+        return cmake_options

--- a/spack_pkgs/spack_repo/compass/packages/amg2023/package.py
+++ b/spack_pkgs/spack_repo/compass/packages/amg2023/package.py
@@ -14,11 +14,12 @@ class Amg2023(CMakePackage, CudaPackage, ROCmPackage):
     arising from problems on unstructured grids. The driver provided here
     builds linear systems for various 3-dimensional problems. It requires
     an installation of hypre-2.27.0 or higher.
+    ** This particular version is the COMPASS PSAAP-IV project version **
     """
 
     tags = ["benchmark"]
     homepage = "https://github.com/LLNL/AMG2023"
-    git = "https://github.com/LLNL/AMG2023.git"
+    git = "https://github.com/COMPASS-PSAAP/AMG2023.git"
 
     license("Apache-2.0")
 

--- a/spack_pkgs/spack_repo/compass/repo.yaml
+++ b/spack_pkgs/spack_repo/compass/repo.yaml
@@ -1,0 +1,4 @@
+# Define the namespace for COMPASS packages
+repo:
+  namespace: compass
+  api: v1.0 # Or newer


### PR DESCRIPTION
As discussed, keeping the spack repo for CUP-ECS until it is finalized. At that point, the old repo should be merged into the new one.